### PR TITLE
support macOS success notification

### DIFF
--- a/sam_buyV2.py
+++ b/sam_buyV2.py
@@ -388,8 +388,13 @@ def order(startRealTime, endRealTime):
         if status:
             print('【成功】哥，咱家有菜了~')
             import os
+            import sys
             file = r"nb.mp3"
-            os.system(file)
+            if sys.platform == 'darwin':
+                # macOS
+                os.system("open " + file)
+            else:
+                os.system(file)
             exit()
         else:
             if myRet.get('code') == 'STORE_HAS_CLOSED':


### PR DESCRIPTION
Thanks @azhan1998 for your great tool!

I found a minor issue. `sys.system("nb.mp3")` is not working on my platform (macOS 12.3.1), below error occurs when placing an order successfully:

```
【成功】哥，咱家有菜了~
sh: ./nb.mp3: Permission denied
```

On macOS, the `open` command can be used to open files by default applications.

So I create this PR to make mac users not miss the order creation notification.