### PR TITLE
增加保供哨兵

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -5,6 +5,7 @@
 deviceid =
 authtoken =
 trackinfo=
+keyword=保供
 
 [system]
 #正序asc 倒序desc


### PR DESCRIPTION
通过搜索“保供关键字”，监控保供物品的出现。
如果发现保供套餐，立刻停止，奏乐通知用户。